### PR TITLE
README: add ./generate.py instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,4 @@ You can also directly generate individual images locally:
 
 This will generate the image in a temporary directory and open it with your configured image viewer,
 from where you can save it wherever you want it.
+See `./generate.py -h` for more options.

--- a/README.md
+++ b/README.md
@@ -50,3 +50,14 @@ export TWITTER_ACCESS_TOKEN_SECRET="<insert-access-token-secret>"
 ```sh
 ./main.py
 ```
+
+### Non-bot usage
+
+You can also directly generate individual images locally:
+
+```sh
+./generate.py 'Twitter admins: is @this_pigeon bad?'
+```
+
+This will generate the image in a temporary directory and open it with your configured image viewer,
+from where you can save it wherever you want it.

--- a/generate.py
+++ b/generate.py
@@ -142,13 +142,21 @@ def generate_image(text, fp):
 
 
 if __name__ == "__main__":
+    import argparse
     import sys
     import tempfile
 
-    fd, filename = tempfile.mkstemp(".png")
-    text = " ".join(sys.argv[1:])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("text", metavar="TEXT", nargs=argparse.REMAINDER, help="the source text, as in a tweet mentioning the bot (but without the mention)")
+    parser.add_argument("-o", "--output", type=argparse.FileType("w+b"), help="the output file (default: a temporary file)")
+    parser.add_argument("-V", "--view", action="store_true", help="open the output file after writing it (on by default if -o is not specified)")
 
-    with os.fdopen(fd, "wb") as fp:
-        generate_image(text, fp)
+    args = parser.parse_args()
+    if args.output is None:
+        args.output = tempfile.NamedTemporaryFile(suffix=".png")
+        args.view = True
 
-    os.execlp("xdg-open", "xdg-open", filename)
+    generate_image(" ".join(args.text), args.output)
+
+    if args.view:
+        os.execlp("xdg-open", "xdg-open", args.output.name)


### PR DESCRIPTION
Since Twitter suspended @this_pigeon (:sob:), I figure these instructions are useful. (I’m not sure if the example message is ideal, though… perhaps we need to tone down the salt ;) )