### PR TITLE
generate: Accept more quotation marks

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -30,7 +30,7 @@ SPEAKER_Y = 1200
 SPEAKER_WIDTH = 850
 SPEAKER_SIZE = 108
 
-BUTTERFLY_REGEX = re.compile(r'^is\s+(".*"|\S+)\s+(.*)$', re.IGNORECASE)
+BUTTERFLY_REGEX = re.compile(r'''^is\s+(['"„“”«»‚‘’‹›].*['"„“”«»‚‘’‹›]|\S+)\s+(.*)$''', re.IGNORECASE)
 
 BUTTERFLY_X = 1000
 BUTTERFLY_Y = 400
@@ -97,7 +97,7 @@ def format_text(text):
     if butterfly == "this":
         butterfly = ""
     else:
-        butterfly = butterfly.strip("\"")
+        butterfly = butterfly.strip('\'"„“”«»‚‘’‹›')
 
     normalized = unicodedata.normalize("NFKD", subtitle)
     if "?" not in normalized:


### PR DESCRIPTION
Accept various other kinds of quotation marks in addition to straight double quotes. (For now, we don’t check if they’re balanced, the quoted part begins and ends with the first known quotation mark of any kind.)

---

If your keyboard supports any of these quotation marks, this is convenient for command-line usage: you don’t need to escape typographic quotation marks for the shell.

```sh
# instead of
./generate.py me: Is \"a single example\" good documentation?
# you can type
./generate.py me: Is “a single example” good documentation?
```